### PR TITLE
Added required Ruby version for the gem

### DIFF
--- a/kindlegen.gemspec
+++ b/kindlegen.gemspec
@@ -5,6 +5,9 @@ require "kindlegen/version"
 Gem::Specification.new do |s|
   s.name        = "kindlegen"
   s.version     = Kindlegen::VERSION
+  s.platform    = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 2.0.0'
+
   s.authors     = ["TADA Tadashi"]
   s.email       = ["t@tdtds.jp"]
   s.homepage    = ""


### PR DESCRIPTION
I was trying to run this gem with Ruby 1.9.3 but got a NoMethodError on lib/kindlegen.rb line 33, because .to_h method for classes is not defined until Ruby 2.0.0.

@tdtds, I think it is a good idea to add this information in the gemspec so that people are aware of this before trying to use this gem.