### PR TITLE
Pass --no-same-owner to tar

### DIFF
--- a/ext/kindlegen/extconf.rb
+++ b/ext/kindlegen/extconf.rb
@@ -9,7 +9,7 @@ File::open('Makefile', 'w') do |w|
     unzip = 'unzip'
 	 "KindleGen_Mac_i386_v2_9.zip"
   when /linux|cygwin/i
-    unzip = 'tar zxf'
+    unzip = 'tar -zx --no-same-owner -f'
 	 "kindlegen_linux_2.6_i386_v2_9.tar.gz"
   when /mingw32/i
     unzip = 'unzip'


### PR DESCRIPTION
When installing Kindlegen on a Docker container on CI, there are a lot of "Cannot change ownership" errors like this:

    tar zxf kindlegen_linux_2.6_i386_v2_9.tar.gz
    tar: docs/german/Bittelesen.txt: Cannot change ownership to uid 311227, gid 100: Invalid argument

`tar` has a `--no-same-owner` option that does not preserve the original owner of the `tar` files. This means that those errors go away, since it just uses whoever the current user is as the owner.