### PR TITLE
Make this compatible with Windows `kindlegen.exe' binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.gem
+*.swp
 /pkg/*
 /.bundle
 /vendor/bundle

--- a/lib/kindlegen.rb
+++ b/lib/kindlegen.rb
@@ -5,16 +5,12 @@ require 'open3'
 module Kindlegen
   Root = Pathname.new(File.expand_path('../..', __FILE__))
   Bin  = Root.join('bin')
-  Executables = Bin.children.inject({}) { |h, p|
-    h[p.basename.to_s.to_sym] = p.to_s
-    h
-  }
 
   #
   # Getting command path of kindlegen.
   #
   def self.command
-    Executables[:kindlegen]
+    Bin.join('kindlegen')
   end
 
   #


### PR DESCRIPTION
Modify extconf.rb to change target based on platform because Windows binary is
`kindlegen.exe` and not `kindlegen`. Include simple tests to see if `curl` and
`unzip` exist in Windows PATH. Make code cleaner.

Modify kindlegen.rb to get command by joining binary directory and "kindlegen".
The previous scheme fails to return the correct command if the binary is
`kindlegen.exe`

Modify .gitignore to ignore *.swp files created by text editor.