### PR TITLE
add mswin32 to suppoted OS

### DIFF
--- a/ext/kindlegen/extconf.rb
+++ b/ext/kindlegen/extconf.rb
@@ -13,7 +13,7 @@ File::open('Makefile', 'w') do |w|
     unzip = 'tar -zx --no-same-owner -f'
     tarball = 'kindlegen_linux_2.6_i386_v2_9.tar.gz'
     target = 'kindlegen'
-  when /mingw32/i
+  when /mingw32|mswin32/i
     unzip = 'unzip'
     # Abort if either `unzip' or `curl' if not found
     `where #{unzip}`


### PR DESCRIPTION
The current extconf.rb cannot detect ruby mswin32 like 
```
> ruby -v
ruby 2.4.0preview2 (2016-09-09 trunk 56129) [i386-mswin32_140] 
```

