### PR TITLE
set TEMP environment variable on windows

### DIFF
--- a/lib/kindlegen.rb
+++ b/lib/kindlegen.rb
@@ -30,6 +30,7 @@ private
   def self.clean_env
     env_backup = ENV.to_h
     ENV.clear
+    ENV['TEMP'] = env_backup['TEMP'] if windows?
     ret = yield
     ENV.replace(env_backup)
     return ret

--- a/lib/kindlegen.rb
+++ b/lib/kindlegen.rb
@@ -21,9 +21,9 @@ module Kindlegen
   #
   def self.run( *params )
     clean_env{Open3.capture3(command.to_s, *params)}.map do |r|
-    	r.force_encoding('UTF-8') if windows? && r.respond_to?(:force_encoding)
-		r
-	 end
+      r.force_encoding('UTF-8') if windows? && r.respond_to?(:force_encoding)
+      r
+    end
   end
 
 private


### PR DESCRIPTION
kindlegen command for Windows need TEMP environment variable.
set TEMP from backup before running kindlegen command. see #21 