### PR TITLE
use `curl -L` to follow redirects

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -31,7 +31,7 @@ def create_task_for_unix(config)
   end
 
   file tarball do
-    sh "curl #{url} -o #{tarball}"
+    sh "curl #{url} -L -o #{tarball}"
   end
 end
 


### PR DESCRIPTION
curl gets empty file without `-L` option.

```
curl http://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v2_9.zip -o KindleGen_Mac_i386_v2_9.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
unzip KindleGen_Mac_i386_v2_9.zip
Archive:  KindleGen_Mac_i386_v2_9.zip
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of KindleGen_Mac_i386_v2_9.zip or
        KindleGen_Mac_i386_v2_9.zip.zip, and cannot find KindleGen_Mac_i386_v2_9.zip.ZIP, period.
```