### PR TITLE
Fix unzipping of kindlegen archive on Windows

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -49,7 +49,7 @@ def unzip(tarball)
   Zip::File.open(tarball).each do |entry|
     dir = File.dirname(entry.name)
     FileUtils.mkpath(dir) if dir != '.' && !File.exist?(dir)
-    entry.extract unless File.exist?(entry.name)
+    entry.extract(dest_path=entry.name) unless File.exist?(entry.name)
   end
 end
 


### PR DESCRIPTION
unzipping was broken due to fixes for CVE-2018-1000544 in rubyzip: [1], [2].

Also, see [3].

Fixes #32.

[1]: https://github.com/rubyzip/rubyzip/pull/371
[2]: https://github.com/rubyzip/rubyzip/pull/376
[3]: https://github.com/rubyzip/rubyzip/issues/354