### PR TITLE
Add GitHub Actions script for Linux & Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        ruby: [2.4, 2.5, 2.6, 2.7]
+        # TODO: https://github.com/tdtds/kindlegen/issues/36
+        # Add macos-latest when kindlegen is fixed to work on Catalina
+        platform: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: eregon/use-ruby-action@master
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: gem install bundler
+      - run: bundle install
+      - run: bundle exec rake build test


### PR DESCRIPTION
MacOS is not added due to absense of 64-bit kindlegen binary (reported as tdtds/kindlegen#36).
GitHub Actions uses Catalina which cannot run 32-bit binaries.

Resolves tdtds/kindlegen#34

eregon/use-ruby-action is used in workflow instead of actions/setup-ruby
because the latter doesn't yet support Ruby 2.7. See actions/setup-ruby#45