### PR TITLE
Extend supported Ruby version to 2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7]
         # TODO: https://github.com/tdtds/kindlegen/issues/36
         # Add macos-latest when kindlegen is fixed to work on Catalina
         platform: [ubuntu-latest, windows-latest]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.4.7
-  - 2.5.7
-  - 2.6.5
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
   - ruby-head
 # NOTE the build step is required to run the tests
 script: bundle exec rake build test

--- a/kindlegen.gemspec
+++ b/kindlegen.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name        = "kindlegen"
   s.version     = Kindlegen::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.3.0'
 
   s.authors     = ["TADA Tadashi"]
   s.email       = ["t@tdtds.jp"]


### PR DESCRIPTION
At least asciidoc-epub3 (one of kindlegen dependants) still supports Ruby-2.3.
However, older kindlegen releases cannot be installed on Windows. See https://github.com/tdtds/kindlegen/issues/32
So, there's a need of at least one release with Ruby 2.3 support.