### PR TITLE
Download kindlegen binary using native Ruby tools

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -4,6 +4,7 @@
 #
 require 'rbconfig'
 require 'fileutils'
+require 'open-uri'
 
 AMAZON = 'http://kindlegen.s3.amazonaws.com'
 BINDIR = '../bin'
@@ -18,29 +19,42 @@ def create_default_task(target)
 end
 
 def create_task_for_unix(config)
+  require 'rubygems/package'
+  require 'zlib'
+
   tarball = config[:tarball]
-  unzip   = config[:unzip]
   target  = config[:target]
   url = "#{AMAZON}/#{tarball}"
 
   create_default_task(target)
 
   file target => tarball do
-    sh "#{unzip} #{tarball}"
-    sh "chmod +x #{target}"
+    Gem::Package::TarReader.new(Zlib::GzipReader.open(tarball)) do |tar|
+      tar.each do |entry|
+        next unless entry.file?
+        next if File.exist?(entry.full_name)
+
+        dir = File.dirname(entry.full_name)
+        FileUtils.mkpath(dir) if dir != '.' && !File.exist?(dir)
+        File.open(entry.full_name, 'wb') do |f|
+          f.write(entry.read)
+        end
+      end
+    end
+    File.chmod(0o755, target)
   end
 
   file tarball do
-    sh "curl #{url} -L -o #{tarball}"
+    curl(url, tarball)
   end
 end
 
-# curl for windows
 def curl(url, tarball)
   puts "open(#{url})"
   puts "save to #{tarball}"
-  data = open(url, 'rb').read
-  open(tarball, 'wb').write(data)
+  open(url) do |file|
+    IO.copy_stream(file, tarball)
+  end
 end
 
 # unzip for windows
@@ -54,7 +68,6 @@ def unzip(tarball)
 end
 
 def create_task_for_windows(config)
-  require 'open-uri'
   require 'zip'
 
   tarball = config[:tarball]
@@ -76,12 +89,10 @@ case RbConfig::CONFIG['host_os']
 when /mac|darwin/i
   create_task_for_unix(
     { tarball: 'KindleGen_Mac_i386_v2_9.zip',
-      unzip:   'unzip',
       target:  'kindlegen' })
 when /linux|cygwin/i
   create_task_for_unix(
     { tarball: 'kindlegen_linux_2.6_i386_v2_9.tar.gz',
-      unzip:   'tar -zx --no-same-owner -f',
       target:  'kindlegen' })
 when /mingw32|mswin32/i
   create_task_for_windows(


### PR DESCRIPTION
This PR workarounds jruby/jruby#5971 by replacing `sh` calls during installation with native Ruby. Otherwise, kindlegen [fails to install](https://github.com/asciidoctor/asciidoctorj-epub3/pull/7/checks?check_run_id=421802589#step:4:51) via jruby-gradle-plugin.