### PR TITLE
resolves #42 use Wayback Machine to download KindleGen binaries

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -6,7 +6,6 @@ require 'rbconfig'
 require 'fileutils'
 require 'open-uri'
 
-AMAZON = 'http://kindlegen.s3.amazonaws.com'
 BINDIR = '../bin'
 
 def create_default_task(target)
@@ -24,7 +23,7 @@ def create_task_for_unix(config)
 
   tarball = config[:tarball]
   target  = config[:target]
-  url = "#{AMAZON}/#{tarball}"
+  url = ENV['KINDLEGEN_TARBALL_URL'] || config[:url]
 
   create_default_task(target)
 
@@ -72,7 +71,7 @@ def create_task_for_windows(config)
 
   tarball = config[:tarball]
   target  = config[:target]
-  url = "#{AMAZON}/#{tarball}"
+  url = ENV['KINDLEGEN_TARBALL_URL'] || config[:url]
 
   create_default_task(target)
 
@@ -89,15 +88,18 @@ case RbConfig::CONFIG['host_os']
 when /mac|darwin/i
   create_task_for_unix(
     { tarball: 'KindleGen_Mac_i386_v2_9.zip',
-      target:  'kindlegen' })
+      target: 'kindlegen',
+      url: 'https://web.archive.org/web/20200814013519/https://kindlegen.s3.amazonaws.com/KindleGen_Mac_i386_v2_9.zip' })
 when /linux|cygwin/i
   create_task_for_unix(
     { tarball: 'kindlegen_linux_2.6_i386_v2_9.tar.gz',
-      target:  'kindlegen' })
+      target: 'kindlegen',
+      url: 'https://web.archive.org/web/20150803131026/https://kindlegen.s3.amazonaws.com/kindlegen_linux_2.6_i386_v2_9.tar.gz' })
 when /mingw32|mswin32/i
   create_task_for_windows(
     { tarball: 'kindlegen_win32_v2_9.zip',
-      target: 'kindlegen.exe' })
+      target: 'kindlegen.exe',
+      url: 'http://web.archive.org/web/20150407060917/http://kindlegen.s3.amazonaws.com/kindlegen_win32_v2_9.zip' })
 else
   STDERR.puts "Host OS unsupported!"
   exit(1)


### PR DESCRIPTION
I think this is a Good Enough workaround for #42 in current situation.

1. `kindlegen` gem is not violating KindleGen EULA because it is not distributing KindleGen binaries. Wayback Machine is distributing them.
2. End-user who installs KindleGen is also not violating EULA.
3. It is very unlikely Amazon will fight with Internet Archive to take down KindleGen binaries from it.