### PR TITLE
Add automated publishing process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Publish to RubyGems.org
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
+    - name: Publish to RubyGems.org
+      uses: dawidd6/action-publish-gem@v1
+      with:
+        api_key: ${{ secrets.RUBYGEMS_API_KEY }}


### PR DESCRIPTION
With workflow from this commit, simple push of a tag to Git repo will trigger automatic Gem publishing to RubyGems.org

The only thing that needs to be set up manually is addition of RUBYGEMS_API_KEY secret to repository secrets at https://github.com/tdtds/kindlegen/settings/secrets/actions

----

@tdtds If would be really nice if you either merged this so I could release a new version with Ruby 3.0 support or if you released it yourself) I'm trying to re-add kindlegen to asciidoctor-epub3, but lack of Ruby 3.0 support blocks me from doing that.